### PR TITLE
Add a second call to ReadFriendsList()

### DIFF
--- a/OnlineSubsystemEOS/Source/EOS_OSS_Tutorial/EOSPlayerController.cpp
+++ b/OnlineSubsystemEOS/Source/EOS_OSS_Tutorial/EOSPlayerController.cpp
@@ -150,9 +150,36 @@ void AEOSPlayerController::HandleLoginCompleted(int32 LocalUserNum, bool bWasSuc
         UE_LOG(LogTemp, Log, TEXT("Login callback completed!"));
         UE_LOG(LogTemp, Log, TEXT("Loading cloud data and searching for a session..."));
         
-         LoadTitleData(); // Load any game related data (in this case a string output to logs)
-         LoadPlayerData(); // Load save game data 
-         FindSessions(); // For convenience a session is found in sequence here. In a real game this would be done via game UI. Goal here is to show EOS functionality, not game design. 
+         //LoadTitleData(); // Load any game related data (in this case a string output to logs)
+         //LoadPlayerData(); // Load save game data 
+         //FindSessions(); // For convenience a session is found in sequence here. In a real game this would be done via game UI. Goal here is to show EOS functionality, not game design. 
+
+         GetWorld()->GetTimerManager().SetTimer(
+           TimerHandle,
+           [=]()
+           {
+              UE_LOG(LogTemp, Warning, TEXT("SetTimer called!"));
+              IOnlineFriendsPtr Friends = Subsystem->GetFriendsInterface();
+              Friends->ReadFriendsList(
+               0,
+               TEXT(""),
+               FOnReadFriendsListComplete::CreateLambda(
+               [=](int32 LocalUserNum, bool bWasSuccessful, const FString& ListName, const FString& ErrorStr)
+               {
+                  TArray<TSharedRef<FOnlineFriend>> FriendsList;
+                  Friends->GetFriendsList(0, TEXT(""), FriendsList);
+                  UE_LOG(LogTemp, Log, TEXT("----------------- ReadFriendsList Start!"));
+                  for (auto Friend : FriendsList)
+                  {
+                    UE_LOG(LogTemp, Log, TEXT("FriendName: %s"), *Friend->GetDisplayName());
+                  }
+                  UE_LOG(LogTemp, Log, TEXT("----------------- ReadFriendsList done!\n"));
+               })
+              );
+           },
+           4.0f,
+           false
+         );
     }
     else //Login failed
     {

--- a/OnlineSubsystemEOS/Source/EOS_OSS_Tutorial/EOSPlayerController.h
+++ b/OnlineSubsystemEOS/Source/EOS_OSS_Tutorial/EOSPlayerController.h
@@ -21,6 +21,8 @@ class EOS_OSS_TUTORIAL_API AEOSPlayerController : public APlayerController
 {
 	GENERATED_BODY()
 
+	FTimerHandle TimerHandle;
+
 public:
 	// Class constructor. We won't use this in this tutorial. 
 	AEOSPlayerController();

--- a/OnlineSubsystemEOS/Source/EOS_OSS_Tutorial/EOS_OSS_Tutorial.Build.cs
+++ b/OnlineSubsystemEOS/Source/EOS_OSS_Tutorial/EOS_OSS_Tutorial.Build.cs
@@ -9,6 +9,7 @@ public class EOS_OSS_Tutorial : ModuleRules
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
 		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "HeadMountedDisplay", "EnhancedInput", "OnlineSubsystem", "OnlineSubsystemUtils", "OnlineSubsystemEOS" });
+		bEnableExceptions = true;
 
         // Tutorial 7: This will set the game to be in P2P mode instead of dedicated server.
         PrivateDefinitions.Add("P2PMODE=0");


### PR DESCRIPTION
Observe that after the second call the GetFriends() won't return the list of friends.

The bug is here in the `FUserManagerEOS::AddFriend()` function:
```cpp
	// Add this friend as a remote player if we haven't already (this will grab user info)
	if (!UniqueNetIdToAttributeAccessMap.Contains(FriendNetId))
	{
		AddRemotePlayer(LocalUserNum, EpicAccountId, FriendRef);
	}
```
The `UniqueNetIdToAttributeAccessMap` basically contains the cached information of friends which is populated during the first call to the `ReadFriendsList()`.

During the second call, here we skip calling the `AddRemotePlayer()` function to avoid making unnecessary requests for obtainig the friends info which we already have in our cache.

However the problem is that we've forgotten to set the friend info using our cached values in the else block. The fix would be to move a piece of code from the ` FUserManagerEOS::ReadUserInfo()` to here:
```cpp
	// Add this friend as a remote player if we haven't already (this will grab user info)
	if (!UniqueNetIdToAttributeAccessMap.Contains(FriendNetId))
	{
		AddRemotePlayer(LocalUserNum, EpicAccountId, FriendRef);
	}
        else
        {
        // set user info from the cached info
            IAttributeAccessInterfaceRef AttributeAccessRef = UniqueNetIdToAttributeAccessMap[FriendNetId];
            FOnlineFriendEOSPtr FriendPtr = LocalUser.FriendsList->GetByNetId(FriendNetId);
            FriendPtr->UpdateInternalAttributes(AttributeAccessRef->GetInternalAttributes());
        }
```
